### PR TITLE
fix: Use of insufficient randomness as the key of a cryptographic algorithm

### DIFF
--- a/handler/leases.go
+++ b/handler/leases.go
@@ -2,7 +2,8 @@ package handler
 
 import (
 	"log"
-	"math/rand"
+	"crypto/rand"
+	"math/big"
 	"net/http"
 	"strconv"
 	"time"
@@ -67,7 +68,12 @@ const (
 func serverRandomness() (serverRandomness string) {
 	b := make([]byte, 11)
 	for i := 0; i < 11; i++ {
-		b[i] = randCharset[rand.Intn(allRandCharsetLen)]
+		num, err := rand.Int(rand.Reader, big.NewInt(int64(allRandCharsetLen)))
+		if err != nil {
+			// Fail securely: log fatal or panic if secure random failed
+			log.Fatalln("crypto/rand failed:", err)
+		}
+		b[i] = randCharset[num.Int64()]
 	}
 	return string(b) + "="
 }


### PR DESCRIPTION
Potential fix for [https://github.com/gythialy/jrebel/security/code-scanning/1](https://github.com/gythialy/jrebel/security/code-scanning/1)

The best fix is to replace the use of `math/rand` with cryptographically secure random generation from `crypto/rand` for all values that will be used in cryptographic contexts. Specifically, in handler/leases.go at the generation of `serverRandomness`, change the for-loop to use `crypto/rand.Read` to produce random bytes, and map those bytes into a valid charset index securely, in a way that is not biased. This generally involves reading a random byte, converting it to an int, and if it is within the acceptable range, mapping it to a character. Also, remove the import for `math/rand` if not otherwise used.

You will need to:
- Import `"crypto/rand"` and `"math/big"` in handler/leases.go.
- Change the logic of `serverRandomness()` to use crypto/rand/big.Int for random indexes in `randCharset`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
