### PR TITLE
fix: Reflected cross-site scripting

### DIFF
--- a/handler/ping.go
+++ b/handler/ping.go
@@ -9,6 +9,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net/http"
+	"html"
 
 	"github.com/gythialy/jrebel/util"
 )
@@ -34,7 +35,7 @@ func PingHandler(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(403)
 		_, _ = fmt.Fprint(w)
 	} else {
-		xmlContent := "<PingResponse><message></message><responseCode>OK</responseCode><salt>" + salt + "</salt></PingResponse>"
+		xmlContent := "<PingResponse><message></message><responseCode>OK</responseCode><salt>" + html.EscapeString(salt) + "</salt></PingResponse>"
 		signature, err := signWithMd5([]byte(xmlContent))
 		if err != nil {
 			w.WriteHeader(http.StatusForbidden)
@@ -55,7 +56,7 @@ func ObtainTicketHandler(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 	} else {
 		w.WriteHeader(http.StatusOK)
-		xmlContent := "<ObtainTicketResponse><message></message><prolongationPeriod>" + prolongationPeriod + "</prolongationPeriod><responseCode>OK</responseCode><salt>" + salt + "</salt><ticketId>1</ticketId><ticketProperties>licensee=" + username + "\tlicenseType=0\t</ticketProperties></ObtainTicketResponse>"
+		xmlContent := "<ObtainTicketResponse><message></message><prolongationPeriod>" + prolongationPeriod + "</prolongationPeriod><responseCode>OK</responseCode><salt>" + html.EscapeString(salt) + "</salt><ticketId>1</ticketId><ticketProperties>licensee=" + html.EscapeString(username) + "\tlicenseType=0\t</ticketProperties></ObtainTicketResponse>"
 		signature, err := signWithMd5([]byte(xmlContent))
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Potential fix for [https://github.com/gythialy/jrebel/security/code-scanning/2](https://github.com/gythialy/jrebel/security/code-scanning/2)

To fix the vulnerability, all data derived from user-controlled parameters must be safely encoded for its output context before writing to the response. For the `PingHandler`, the "salt" parameter is included in a string served as HTML (wrapped in XML-like markup). The best solution is to escape `salt` using contextual HTML encoding since the output is served under an HTML content-type header. In Go, this is done by using `html.EscapeString`. 

For completeness and defense-in-depth, any user-provided data forming the response—such as "salt" and also "username" in `ObtainTicketHandler`—should be escaped before interpolating them. So, change both the relevant lines in `PingHandler` and `ObtainTicketHandler` to escape these values before concatenation.

Add the import statement for the standard `html` package in `handler/ping.go` to use `html.EscapeString`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
